### PR TITLE
Refactor Era encoding/decoding

### DIFF
--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/EraReader.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/EraReader.java
@@ -1,4 +1,4 @@
-package io.emeraldpay.polkaj.scale.reader;
+package io.emeraldpay.polkaj.scaletypes;
 
 import io.emeraldpay.polkaj.scale.ScaleCodecReader;
 import io.emeraldpay.polkaj.scale.ScaleReader;

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/EraWriter.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/EraWriter.java
@@ -1,4 +1,4 @@
-package io.emeraldpay.polkaj.scale.writer;
+package io.emeraldpay.polkaj.scaletypes;
 
 import io.emeraldpay.polkaj.scale.ScaleWriter;
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter;

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/ExtrinsicReader.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/ExtrinsicReader.java
@@ -50,6 +50,7 @@ public class ExtrinsicReader<CALL extends ExtrinsicCall> implements ScaleReader<
                     new UnsupportedReader<>("ECDSA signatures are not supported")
                 )
         );
+        private static final EraReader ERA_READER = new EraReader();
 
         private final SS58Type.Network network;
 
@@ -62,7 +63,7 @@ public class ExtrinsicReader<CALL extends ExtrinsicCall> implements ScaleReader<
             Extrinsic.TransactionInfo result = new Extrinsic.TransactionInfo();
             result.setSender(new Address(network, rdr.readUint256()));
             result.setSignature(rdr.read(SIGNATURE_READER).getValue());
-            result.setEra(rdr.readEra());
+            result.setEra(rdr.read(ERA_READER));
             result.setNonce(rdr.read(ScaleCodecReader.COMPACT_BIGINT).longValueExact());
             result.setTip(new DotAmount(rdr.read(ScaleCodecReader.COMPACT_BIGINT)));
             return result;

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/ExtrinsicWriter.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/ExtrinsicWriter.java
@@ -30,12 +30,15 @@ public class ExtrinsicWriter<CALL extends ExtrinsicCall> implements ScaleWriter<
     }
 
     static class TransactionInfoWriter implements ScaleWriter<Extrinsic.TransactionInfo> {
+
+        private static final EraWriter ERA_WRITER = new EraWriter();
+
         @Override
         public void write(ScaleCodecWriter wrt, Extrinsic.TransactionInfo value) throws IOException {
             wrt.writeUint256(value.getSender().getPubkey());
             wrt.writeByte(Extrinsic.SignatureType.SR25519.getCode());
             wrt.writeByteArray(value.getSignature().getValue().getBytes());
-            wrt.writeEra(value.getEra());
+            wrt.write(ERA_WRITER, value.getEra());
             wrt.write(ScaleCodecWriter.COMPACT_BIGINT, BigInteger.valueOf(value.getNonce()));
             wrt.write(ScaleCodecWriter.COMPACT_BIGINT, value.getTip().getValue());
         }

--- a/polkaj-scale-types/src/test/groovy/io/emeraldpay/polkaj/scaletypes/EraReaderSpec.groovy
+++ b/polkaj-scale-types/src/test/groovy/io/emeraldpay/polkaj/scaletypes/EraReaderSpec.groovy
@@ -1,4 +1,4 @@
-package io.emeraldpay.polkaj.scale.reader
+package io.emeraldpay.polkaj.scaletypes
 
 import io.emeraldpay.polkaj.scale.ScaleCodecReader
 import org.apache.commons.codec.binary.Hex

--- a/polkaj-scale-types/src/test/groovy/io/emeraldpay/polkaj/scaletypes/EraWriterSpec.groovy
+++ b/polkaj-scale-types/src/test/groovy/io/emeraldpay/polkaj/scaletypes/EraWriterSpec.groovy
@@ -1,4 +1,4 @@
-package io.emeraldpay.polkaj.scale.writer
+package io.emeraldpay.polkaj.scaletypes
 
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter
 import org.apache.commons.codec.binary.Hex

--- a/polkaj-scale/src/main/java/io/emeraldpay/polkaj/scale/ScaleCodecReader.java
+++ b/polkaj-scale/src/main/java/io/emeraldpay/polkaj/scale/ScaleCodecReader.java
@@ -17,7 +17,6 @@ public class ScaleCodecReader {
     public static final Int32Reader INT32 = new Int32Reader();
     public static final CompactUIntReader COMPACT_UINT = new CompactUIntReader();
     public static final CompactBigIntReader COMPACT_BIGINT = new CompactBigIntReader();
-    public static final EraReader ERA = new EraReader();
     public static final BoolReader BOOL = new BoolReader();
     public static final BoolOptionalReader BOOL_OPTIONAL = new BoolOptionalReader();
     public static final StringReader STRING = new StringReader();
@@ -103,10 +102,6 @@ public class ScaleCodecReader {
 
     public int readCompactInt() {
         return COMPACT_UINT.read(this);
-    }
-
-    public int readEra() {
-        return ERA.read(this);
     }
 
     public boolean readBoolean() {

--- a/polkaj-scale/src/main/java/io/emeraldpay/polkaj/scale/ScaleCodecWriter.java
+++ b/polkaj-scale/src/main/java/io/emeraldpay/polkaj/scale/ScaleCodecWriter.java
@@ -12,7 +12,6 @@ public class ScaleCodecWriter implements Closeable {
 
     public static final CompactUIntWriter COMPACT_UINT = new CompactUIntWriter();
     public static final CompactBigIntWriter COMPACT_BIGINT = new CompactBigIntWriter();
-    public static final EraWriter ERA = new EraWriter();
     public static final UInt16Writer UINT16 = new UInt16Writer();
     public static final UInt32Writer UINT32 = new UInt32Writer();
     public static final UInt128Writer UINT128 = new UInt128Writer();
@@ -83,10 +82,6 @@ public class ScaleCodecWriter implements Closeable {
 
     public void writeByte(byte value) throws IOException {
         directWrite(value);
-    }
-
-    public void writeEra(int value) throws IOException {
-        ERA.write(this, value);
     }
 
     public void writeUint16(int value) throws IOException {

--- a/polkaj-tx/src/main/java/io/emeraldpay/polkaj/tx/ExtrinsicSigner.java
+++ b/polkaj-tx/src/main/java/io/emeraldpay/polkaj/tx/ExtrinsicSigner.java
@@ -5,6 +5,7 @@ import io.emeraldpay.polkaj.scale.ScaleWriter;
 import io.emeraldpay.polkaj.scaletypes.BalanceTransfer;
 import io.emeraldpay.polkaj.scaletypes.BalanceTransferWriter;
 import io.emeraldpay.polkaj.scaletypes.ExtrinsicCall;
+import io.emeraldpay.polkaj.scaletypes.EraWriter;
 import io.emeraldpay.polkaj.schnorrkel.Schnorrkel;
 import io.emeraldpay.polkaj.schnorrkel.SchnorrkelException;
 import io.emeraldpay.polkaj.types.Address;
@@ -118,6 +119,8 @@ public class ExtrinsicSigner<CALL extends ExtrinsicCall> {
 
     public static class SignaturePayloadWriter<CALL extends ExtrinsicCall> implements ScaleWriter<SignaturePayload<CALL>> {
 
+        private static final EraWriter ERA_WRITER = new EraWriter();
+
         private final ScaleWriter<CALL> callScaleWriter;
         private final boolean callAsList;
 
@@ -142,7 +145,7 @@ public class ExtrinsicSigner<CALL extends ExtrinsicCall> {
             } else {
                 wrt.write(callScaleWriter, signPayload.getCall());
             }
-            wrt.write(ScaleCodecWriter.ERA, context.getEra().toInteger());
+            wrt.write(ERA_WRITER, context.getEra().toInteger());
             wrt.write(ScaleCodecWriter.COMPACT_BIGINT, BigInteger.valueOf(context.getNonce()));
             wrt.write(ScaleCodecWriter.COMPACT_BIGINT, context.getTip().getValue());
             wrt.writeUint32(context.getRuntimeVersion());


### PR DESCRIPTION
This PR moves the Era codec out of the 'scale' package and into the 'scaletypes' one, based on the feedback on https://github.com/emeraldpay/polkaj/pull/41