### PR TITLE
Support for runtime v30

### DIFF
--- a/polkaj-api-http/src/test/groovy/io/emeraldpay/polkaj/apihttp/PolkadotHttpClientSpec.groovy
+++ b/polkaj-api-http/src/test/groovy/io/emeraldpay/polkaj/apihttp/PolkadotHttpClientSpec.groovy
@@ -123,7 +123,7 @@ class PolkadotHttpClientSpec extends Specification {
                 '        "stateRoot": "0x0984f5c13d7d271467332697fa5fc191539c1441f5ca1b234618ff25638b7d66"' +
                 '      }' +
                 '    },' +
-                '    "justification": null' +
+                '    "justifications": []' +
                 '  },' +
                 '  "id": 0' +
                 '}'
@@ -140,7 +140,7 @@ class PolkadotHttpClientSpec extends Specification {
                         .withBody('{"jsonrpc":"2.0","id":0,"method":"chain_getBlock","params":["0x9130103f8fbca52a79042211383946b39e6269b6ab49bc08035c9893d782c1bb"]}')
         )
 
-        act.justification == null
+        act.justifications.length == 0
         act.block != null
         with(act.block) {
             header.number == 0x401a1

--- a/polkaj-json-types/src/main/java/io/emeraldpay/polkaj/json/BlockResponseJson.java
+++ b/polkaj-json-types/src/main/java/io/emeraldpay/polkaj/json/BlockResponseJson.java
@@ -1,11 +1,12 @@
 package io.emeraldpay.polkaj.json;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 public class BlockResponseJson {
 
     private BlockJson block;
-    private Object justification;
+    private Object[] justifications;
 
     public BlockResponseJson() {
     }
@@ -22,12 +23,12 @@ public class BlockResponseJson {
         this.block = block;
     }
 
-    public Object getJustification() {
-        return justification;
+    public Object[] getJustifications() {
+        return justifications;
     }
 
-    public void setJustification(Object justification) {
-        this.justification = justification;
+    public void setJustifications(Object[] justifications) {
+        this.justifications = justifications;
     }
 
     @Override
@@ -36,11 +37,13 @@ public class BlockResponseJson {
         if (!(o instanceof BlockResponseJson)) return false;
         BlockResponseJson that = (BlockResponseJson) o;
         return Objects.equals(block, that.block) &&
-                Objects.equals(justification, that.justification);
+                Arrays.equals(justifications, that.justifications);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(block, justification);
+        int result = Objects.hash(block);
+        result = 31 * result + Arrays.hashCode(justifications);
+        return result;
     }
 }

--- a/polkaj-json-types/src/test/groovy/io/emeraldpay/polkaj/json/BlockResponseJsonSpec.groovy
+++ b/polkaj-json-types/src/test/groovy/io/emeraldpay/polkaj/json/BlockResponseJsonSpec.groovy
@@ -15,7 +15,7 @@ class BlockResponseJsonSpec extends Specification {
         then:
         act != null
         act.block != null
-        act.justification == null
+        act.justifications.length == 0
         with(act.block) {
             extrinsics.size() == 3
             with(header) {

--- a/polkaj-json-types/src/test/resources/blocks/0x401a1-full.json
+++ b/polkaj-json-types/src/test/resources/blocks/0x401a1-full.json
@@ -18,5 +18,5 @@
       "stateRoot": "0x0984f5c13d7d271467332697fa5fc191539c1441f5ca1b234618ff25638b7d66"
     }
   },
-  "justification": null
+  "justifications": []
 }

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/AccountInfo.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/AccountInfo.java
@@ -7,6 +7,7 @@ public class AccountInfo {
     private Long nonce;
     private Long consumers;
     private Long providers;
+    private Long sufficients;
     private AccountData data;
 
     public Long getNonce() {
@@ -33,6 +34,14 @@ public class AccountInfo {
         this.providers = providers;
     }
 
+    public Long getSufficients() {
+        return sufficients;
+    }
+
+    public void setSufficients(Long sufficients) {
+        this.sufficients = sufficients;
+    }
+
     public AccountData getData() {
         return data;
     }
@@ -49,11 +58,12 @@ public class AccountInfo {
         return Objects.equals(nonce, that.nonce) &&
                 Objects.equals(consumers, that.consumers) &&
                 Objects.equals(providers, that.providers) &&
+                Objects.equals(sufficients, that.sufficients) &&
                 Objects.equals(data, that.data);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(nonce, consumers, providers, data);
+        return Objects.hash(nonce, consumers, providers, sufficients, data);
     }
 }

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/AccountInfoReader.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/AccountInfoReader.java
@@ -10,6 +10,7 @@ public class AccountInfoReader implements ScaleReader<AccountInfo> {
         result.setNonce(rdr.readUint32());
         result.setConsumers(rdr.readUint32());
         result.setProviders(rdr.readUint32());
+        result.setSufficients(rdr.readUint32());
         result.setData(rdr.read(new AccountDataReader()));
         return result;
     }

--- a/polkaj-scale-types/src/test/groovy/io/emeraldpay/polkaj/scaletypes/AccountInfoReaderSpec.groovy
+++ b/polkaj-scale-types/src/test/groovy/io/emeraldpay/polkaj/scaletypes/AccountInfoReaderSpec.groovy
@@ -11,7 +11,7 @@ class AccountInfoReaderSpec extends Specification {
 
     def "Read value"() {
         setup:
-        def value = Hex.decodeHex("110000000300000004000000f70af5f6f3c843050000000000000000000000000000000000000000000000000000c52ebca2b10000000000000000000000c52ebca2b1000000000000000000")
+        def value = Hex.decodeHex("11000000030000000400000005000000f70af5f6f3c843050000000000000000000000000000000000000000000000000000c52ebca2b10000000000000000000000c52ebca2b1000000000000000000")
         when:
         def act = new ScaleCodecReader(value).read(reader)
         then:
@@ -19,6 +19,7 @@ class AccountInfoReaderSpec extends Specification {
         act.nonce == 17
         act.consumers == 3
         act.providers == 4
+        act.sufficients == 5
         with(act.data) {
             free == DotAmount.fromPlancks(379367743775116023)
             reserved == DotAmount.ZERO

--- a/polkaj-tx/src/test/groovy/io/emeraldpay/polkaj/tx/AccountRequestsSpec.groovy
+++ b/polkaj-tx/src/test/groovy/io/emeraldpay/polkaj/tx/AccountRequestsSpec.groovy
@@ -38,13 +38,14 @@ class AccountRequestsSpec extends Specification {
     def "Decode balance response"() {
         setup:
         def req = AccountRequests.balanceOf(Address.from("1WG3jyNqniQMRZGQUc7QD2kVLT8hkRPGMSqAb5XYQM1UDxN"))
-        def result = ByteData.from("0x110000000300000004000000f70af5f6f3c843050000000000000000000000000000000000000000000000000000c52ebca2b10000000000000000000000c52ebca2b1000000000000000000")
+        def result = ByteData.from("0x11000000030000000400000005000000f70af5f6f3c843050000000000000000000000000000000000000000000000000000c52ebca2b10000000000000000000000c52ebca2b1000000000000000000")
         when:
         def act = req.apply(result)
         then:
         act.nonce == 17
         act.consumers == 3
         act.providers == 4
+        act.sufficients == 5
         with(act.data) {
             free == DotAmount.fromPlancks(379367743775116023)
             reserved == DotAmount.ZERO

--- a/polkaj-tx/src/test/groovy/io/emeraldpay/polkaj/tx/ExtrinsicContextAutoBuilderSpec.groovy
+++ b/polkaj-tx/src/test/groovy/io/emeraldpay/polkaj/tx/ExtrinsicContextAutoBuilderSpec.groovy
@@ -19,7 +19,7 @@ class ExtrinsicContextAutoBuilderSpec extends Specification {
                     StandardCommands.getInstance().stateGetStorage(requestAccount.encodeRequest())
             ) >> CompletableFuture.completedFuture(
                     // 1,000,000.00 Dot, nonce = 1
-                    ByteData.from("0x01000000000000000000000019e4759db3b6e00d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
+                    ByteData.from("0x0100000000000000000000000000000019e4759db3b6e00d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
             )
             1 * execute(
                     StandardCommands.getInstance().getBlockHash(0)


### PR DESCRIPTION
This PR adds support for 2 breaking changes introduced in runtime v30:

 - Self-sufficient account ref-counting (https://github.com/paritytech/substrate/pull/8221)
 - Storing multiple Justifications per block (https://github.com/paritytech/substrate/pull/7640/files)
