### PR TITLE
Add support for ED25519 signatures, include tip in TransferBuilder

### DIFF
--- a/polkaj-common-types/src/main/java/io/emeraldpay/polkaj/types/Units.java
+++ b/polkaj-common-types/src/main/java/io/emeraldpay/polkaj/types/Units.java
@@ -10,6 +10,7 @@ import java.util.Objects;
  * @see DotAmount
  * @see DotAmount#Polkadots
  * @see DotAmount#Kusamas
+ * @see DotAmount#Westies
  * @see Units.Unit
  */
 public class Units {
@@ -18,6 +19,11 @@ public class Units {
     public static final Unit Microdot = new Unit("Microdot", "uDOT", 4);
     public static final Unit Millidot = new Unit("Millidot", "mDOT", 7);
     public static final Unit Dot = new Unit("Dot", "DOT", 10);
+
+    public static final Unit Point = new Unit("Point", 3);
+    public static final Unit Micrownd = new Unit("Micrownd", "uWND", 6);
+    public static final Unit Milliwnd = new Unit("Milliwnd", "mWND", 9);
+    public static final Unit Wnd = new Unit("Wnd", "WND", 12);
 
     private final Unit[] units;
 

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/AccountData.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/AccountData.java
@@ -1,8 +1,8 @@
 package io.emeraldpay.polkaj.scaletypes;
 
-import io.emeraldpay.polkaj.types.DotAmount;
-
 import java.util.Objects;
+
+import io.emeraldpay.polkaj.types.DotAmount;
 
 public class AccountData {
 
@@ -57,5 +57,15 @@ public class AccountData {
     @Override
     public int hashCode() {
         return Objects.hash(free, reserved, miscFrozen, feeFrozen);
+    }
+
+    @Override
+    public String toString() {
+        return "AccountData{" +
+                "free=" + free +
+                ", reserved=" + reserved +
+                ", miscFrozen=" + miscFrozen +
+                ", feeFrozen=" + feeFrozen +
+                '}';
     }
 }

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/AccountDataReader.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/AccountDataReader.java
@@ -2,16 +2,24 @@ package io.emeraldpay.polkaj.scaletypes;
 
 import io.emeraldpay.polkaj.scale.ScaleCodecReader;
 import io.emeraldpay.polkaj.scale.ScaleReader;
+import io.emeraldpay.polkaj.ss58.SS58Type;
 
 public class AccountDataReader implements ScaleReader<AccountData> {
+
+    private final SS58Type.Network network;
+
+    public AccountDataReader(SS58Type.Network network) {
+        this.network = network;
+    }
 
     @Override
     public AccountData read(ScaleCodecReader rdr) {
         AccountData result = new AccountData();
-        result.setFree(rdr.read(BalanceReader.INSTANCE));
-        result.setReserved(rdr.read(BalanceReader.INSTANCE));
-        result.setMiscFrozen(rdr.read(BalanceReader.INSTANCE));
-        result.setFeeFrozen(rdr.read(BalanceReader.INSTANCE));
+        BalanceReader balanceReader = new BalanceReader(network);
+        result.setFree(rdr.read(balanceReader));
+        result.setReserved(rdr.read(balanceReader));
+        result.setMiscFrozen(rdr.read(balanceReader));
+        result.setFeeFrozen(rdr.read(balanceReader));
         return result;
     }
 }

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/AccountInfo.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/AccountInfo.java
@@ -66,4 +66,15 @@ public class AccountInfo {
     public int hashCode() {
         return Objects.hash(nonce, consumers, providers, sufficients, data);
     }
+
+    @Override
+    public String toString() {
+        return "AccountInfo{" +
+                "nonce=" + nonce +
+                ", consumers=" + consumers +
+                ", providers=" + providers +
+                ", sufficients=" + sufficients +
+                ", data=" + data +
+                '}';
+    }
 }

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/AccountInfoReader.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/AccountInfoReader.java
@@ -2,8 +2,16 @@ package io.emeraldpay.polkaj.scaletypes;
 
 import io.emeraldpay.polkaj.scale.ScaleCodecReader;
 import io.emeraldpay.polkaj.scale.ScaleReader;
+import io.emeraldpay.polkaj.ss58.SS58Type;
 
 public class AccountInfoReader implements ScaleReader<AccountInfo> {
+
+    private final SS58Type.Network network;
+
+    public AccountInfoReader(SS58Type.Network network) {
+        this.network = network;
+    }
+
     @Override
     public AccountInfo read(ScaleCodecReader rdr) {
         AccountInfo result = new AccountInfo();
@@ -11,7 +19,7 @@ public class AccountInfoReader implements ScaleReader<AccountInfo> {
         result.setConsumers(rdr.readUint32());
         result.setProviders(rdr.readUint32());
         result.setSufficients(rdr.readUint32());
-        result.setData(rdr.read(new AccountDataReader()));
+        result.setData(rdr.read(new AccountDataReader(network)));
         return result;
     }
 }

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/BalanceReader.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/BalanceReader.java
@@ -2,17 +2,36 @@ package io.emeraldpay.polkaj.scaletypes;
 
 import io.emeraldpay.polkaj.scale.ScaleCodecReader;
 import io.emeraldpay.polkaj.scale.ScaleReader;
+import io.emeraldpay.polkaj.ss58.SS58Type;
 import io.emeraldpay.polkaj.types.DotAmount;
+import io.emeraldpay.polkaj.types.Units;
 
 /**
  * Decode balance encoded as uint128
  */
 public class BalanceReader implements ScaleReader<DotAmount> {
 
-    public static final BalanceReader INSTANCE = new BalanceReader();
+    private final Units units;
+
+    /**
+     * Create a default balance reader for the Polkadot network, i.e. DOT.
+     */
+    public BalanceReader() {
+        this.units = DotAmount.Polkadots;
+    }
+
+    /**
+     * <p>Create a balance reader for the provided network.</p>
+     * <p>Transforms the read balance to the unit matching the network (DOT, KSM, WND).</p>
+     *
+     * @param network the SS58 network whose unit to consider when reading accounts
+     */
+    public BalanceReader(SS58Type.Network network) {
+        this.units = DotAmount.getUnitsForNetwork(network);
+    }
 
     @Override
     public DotAmount read(ScaleCodecReader rdr) {
-        return new DotAmount(rdr.readUint128());
+        return new DotAmount(rdr.readUint128(), units);
     }
 }

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/BalanceTransfer.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/BalanceTransfer.java
@@ -1,10 +1,10 @@
 package io.emeraldpay.polkaj.scaletypes;
 
+import java.util.Objects;
+
 import io.emeraldpay.polkaj.scale.UnionValue;
 import io.emeraldpay.polkaj.types.Address;
 import io.emeraldpay.polkaj.types.DotAmount;
-
-import java.util.Objects;
 
 /**
  * Call to transfer [part of] balance to another address
@@ -84,4 +84,11 @@ public class BalanceTransfer extends ExtrinsicCall {
         return (o instanceof BalanceTransfer);
     }
 
+    @Override
+    public String toString() {
+        return "BalanceTransfer{" +
+                "destination=" + destination +
+                ", balance=" + balance +
+                '}';
+    }
 }

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/BalanceTransfer.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/BalanceTransfer.java
@@ -39,8 +39,18 @@ public class BalanceTransfer extends ExtrinsicCall {
      * @param metadata current Runtime
      */
     public void init(Metadata metadata) {
-        Metadata.Call call = metadata.findCall("Balances", "transfer")
-                .orElseThrow(() -> new IllegalStateException("Call 'Balances.transfer' doesn't exist"));
+        init(metadata, "transfer");
+    }
+
+    /**
+     * Initialize call index for given call of the Balance module from Runtime Metadata
+     *
+     * @param metadata current Runtime
+     * @param callName name of the call to execute, e.g. transfer, transfer_keep_alive, or transfer_all
+     */
+    public void init(Metadata metadata, String callName) {
+        Metadata.Call call = metadata.findCall("Balances", callName)
+                .orElseThrow(() -> new IllegalStateException("Call 'Balances." + callName + "' doesn't exist"));
         init(call);
     }
 

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/BalanceTransferReader.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/BalanceTransferReader.java
@@ -3,15 +3,17 @@ package io.emeraldpay.polkaj.scaletypes;
 import io.emeraldpay.polkaj.scale.ScaleCodecReader;
 import io.emeraldpay.polkaj.scale.ScaleReader;
 import io.emeraldpay.polkaj.ss58.SS58Type;
-import io.emeraldpay.polkaj.types.Address;
 import io.emeraldpay.polkaj.types.DotAmount;
 
 public class BalanceTransferReader implements ScaleReader<BalanceTransfer> {
 
     private final MultiAddressReader destinationReader;
 
+    private final SS58Type.Network network;
+
     public BalanceTransferReader(SS58Type.Network network) {
         this.destinationReader = new MultiAddressReader(network);
+        this.network = network;
     }
 
     @Override
@@ -20,7 +22,7 @@ public class BalanceTransferReader implements ScaleReader<BalanceTransfer> {
         result.setModuleIndex(rdr.readUByte());
         result.setCallIndex(rdr.readUByte());
         result.setDestination(rdr.read(destinationReader));
-        result.setBalance(new DotAmount(rdr.read(ScaleCodecReader.COMPACT_BIGINT)));
+        result.setBalance(new DotAmount(rdr.read(ScaleCodecReader.COMPACT_BIGINT), network));
         return result;
     }
 }

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/Extrinsic.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/Extrinsic.java
@@ -1,11 +1,11 @@
 package io.emeraldpay.polkaj.scaletypes;
 
+import java.util.Objects;
+
 import io.emeraldpay.polkaj.scale.UnionValue;
 import io.emeraldpay.polkaj.types.Address;
 import io.emeraldpay.polkaj.types.DotAmount;
 import io.emeraldpay.polkaj.types.Hash512;
-
-import java.util.Objects;
 
 /**
  * Extrinsic Data, contains main details {@link #tx} with signature and other initial definitions, and the actual
@@ -56,7 +56,7 @@ public class Extrinsic<CALL extends ExtrinsicCall> {
         return Objects.hash(tx, call);
     }
 
-    public static enum SignatureType {
+    public enum SignatureType {
         ED25519(0),
         SR25519(1),
         ECDSA(2);
@@ -93,7 +93,7 @@ public class Extrinsic<CALL extends ExtrinsicCall> {
         /**
          * Signature
          */
-        private SR25519Signature signature;
+        private Signature signature;
         /**
          * Era to execute extrinsic. Immortal by default (i.e. 0)
          */
@@ -119,11 +119,11 @@ public class Extrinsic<CALL extends ExtrinsicCall> {
             this.sender = MultiAddress.AccountID.from(value);
         }
 
-        public SR25519Signature getSignature() {
+        public Signature getSignature() {
             return signature;
         }
 
-        public void setSignature(SR25519Signature signature) {
+        public void setSignature(Signature signature) {
             this.signature = signature;
         }
 
@@ -167,12 +167,27 @@ public class Extrinsic<CALL extends ExtrinsicCall> {
         public int hashCode() {
             return Objects.hash(sender, era, nonce);
         }
+
+        @Override
+        public String toString() {
+            return "TransactionInfo{" +
+                    "sender=" + sender +
+                    ", signature=" + signature +
+                    ", era=" + era +
+                    ", nonce=" + nonce +
+                    ", tip=" + tip +
+                    '}';
+        }
     }
 
-    public static class SR25519Signature {
+    public abstract static class Signature {
+
+        private final SignatureType type;
+
         private final Hash512 value;
 
-        public SR25519Signature(Hash512 value) {
+        protected Signature(SignatureType type, Hash512 value) {
+            this.type = type;
             this.value = value;
         }
 
@@ -181,21 +196,54 @@ public class Extrinsic<CALL extends ExtrinsicCall> {
         }
 
         public SignatureType getType() {
-            return SignatureType.SR25519;
+            return type;
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof SR25519Signature)) return false;
-            SR25519Signature that = (SR25519Signature) o;
-            return Objects.equals(value, that.value);
+        public final boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Signature signature = (Signature) o;
+            return type == signature.type && Objects.equals(value, signature.value);
         }
 
         @Override
-        public int hashCode() {
-            return Objects.hash(value);
+        public final int hashCode() {
+            return Objects.hash(type, value);
+        }
+
+        @Override
+        public String toString() {
+            return "Signature{" +
+                    "type=" + getType() +
+                    ", value=" + value +
+                    '}';
         }
     }
 
+    public static final class SR25519Signature extends Signature {
+
+        public SR25519Signature(Hash512 value) {
+            super(SignatureType.SR25519, value);
+        }
+    }
+
+    public static final class ED25519Signature extends Signature {
+
+        public ED25519Signature(Hash512 value) {
+            super(SignatureType.ED25519, value);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Extrinsic{" +
+                "tx=" + tx +
+                ", call=" + call +
+                '}';
+    }
 }

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/ExtrinsicCall.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/ExtrinsicCall.java
@@ -82,4 +82,12 @@ public abstract class ExtrinsicCall {
     public boolean canEquals(Object o) {
         return (o instanceof ExtrinsicCall);
     }
+
+    @Override
+    public String toString() {
+        return "ExtrinsicCall{" +
+                "moduleIndex=" + moduleIndex +
+                ", callIndex=" + callIndex +
+                '}';
+    }
 }

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/ExtrinsicReader.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/ExtrinsicReader.java
@@ -54,8 +54,11 @@ public class ExtrinsicReader<CALL extends ExtrinsicCall> implements ScaleReader<
 
         private final MultiAddressReader senderReader;
 
+        private final SS58Type.Network network;
+
         public TransactionInfoReader(SS58Type.Network network) {
             this.senderReader = new MultiAddressReader(network);
+            this.network = network;
         }
 
         @Override
@@ -65,7 +68,7 @@ public class ExtrinsicReader<CALL extends ExtrinsicCall> implements ScaleReader<
             readSignature(result, rdr);
             result.setEra(rdr.read(ERA_READER));
             result.setNonce(rdr.read(ScaleCodecReader.COMPACT_BIGINT).longValueExact());
-            result.setTip(new DotAmount(rdr.read(ScaleCodecReader.COMPACT_BIGINT)));
+            result.setTip(new DotAmount(rdr.read(ScaleCodecReader.COMPACT_BIGINT), network));
             return result;
         }
 

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/ExtrinsicWriter.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/ExtrinsicWriter.java
@@ -1,11 +1,11 @@
 package io.emeraldpay.polkaj.scaletypes;
 
-import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
-import io.emeraldpay.polkaj.scale.ScaleWriter;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+
+import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
+import io.emeraldpay.polkaj.scale.ScaleWriter;
 
 public class ExtrinsicWriter<CALL extends ExtrinsicCall> implements ScaleWriter<Extrinsic<CALL>> {
 
@@ -37,11 +37,16 @@ public class ExtrinsicWriter<CALL extends ExtrinsicCall> implements ScaleWriter<
         @Override
         public void write(ScaleCodecWriter wrt, Extrinsic.TransactionInfo value) throws IOException {
             wrt.write(SENDER_WRITER, value.getSender());
-            wrt.writeByte(Extrinsic.SignatureType.SR25519.getCode());
-            wrt.writeByteArray(value.getSignature().getValue().getBytes());
+            writeSignature(wrt, value);
             wrt.write(ERA_WRITER, value.getEra());
             wrt.write(ScaleCodecWriter.COMPACT_BIGINT, BigInteger.valueOf(value.getNonce()));
             wrt.write(ScaleCodecWriter.COMPACT_BIGINT, value.getTip().getValue());
+        }
+
+        private void writeSignature(ScaleCodecWriter wrt, Extrinsic.TransactionInfo value) throws IOException {
+            Extrinsic.Signature signature = value.getSignature();
+            wrt.writeByte(signature.getType().getCode());
+            wrt.writeByteArray(signature.getValue().getBytes());
         }
     }
 }

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/Metadata.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/Metadata.java
@@ -711,4 +711,11 @@ public class Metadata {
         }
     }
 
+    @Override
+    public String toString() {
+        return "Metadata{" +
+                "magic=" + magic +
+                ", version=" + version +
+                '}';
+    }
 }

--- a/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/MultiAddress.java
+++ b/polkaj-scale-types/src/main/java/io/emeraldpay/polkaj/scaletypes/MultiAddress.java
@@ -1,9 +1,9 @@
 package io.emeraldpay.polkaj.scaletypes;
 
+import java.util.Objects;
+
 import io.emeraldpay.polkaj.scale.UnionValue;
 import io.emeraldpay.polkaj.types.Address;
-
-import java.util.Objects;
 
 /**
  * Represents the MultiAddress enum defined in Substrate
@@ -79,6 +79,13 @@ public abstract class MultiAddress {
 
         public boolean canEquals(Object o) {
             return (o instanceof AccountID);
+        }
+
+        @Override
+        public String toString() {
+            return "AccountID{" +
+                    "address=" + address +
+                    '}';
         }
     }
 }

--- a/polkaj-scale-types/src/test/groovy/io/emeraldpay/polkaj/scaletypes/BalanceReaderSpec.groovy
+++ b/polkaj-scale-types/src/test/groovy/io/emeraldpay/polkaj/scaletypes/BalanceReaderSpec.groovy
@@ -1,15 +1,16 @@
 package io.emeraldpay.polkaj.scaletypes
 
 import io.emeraldpay.polkaj.scale.ScaleCodecReader
+import io.emeraldpay.polkaj.ss58.SS58Type
 import io.emeraldpay.polkaj.types.DotAmount
 import org.apache.commons.codec.binary.Hex
 import spock.lang.Specification
 
 class BalanceReaderSpec extends Specification {
 
-    BalanceReader reader = new BalanceReader()
-
     def "Read values"() {
+        BalanceReader reader = new BalanceReader()
+
         expect:
         new ScaleCodecReader(Hex.decodeHex(hex)).read(reader) == balance
         where:
@@ -17,5 +18,29 @@ class BalanceReaderSpec extends Specification {
         "f70af5f6f3c843050000000000000000"  | DotAmount.fromPlancks("379367743775116023")
         "0000c52ebca2b1000000000000000000"  | DotAmount.fromDots(5000000)
         "00000000000000000000000000000000"  | DotAmount.ZERO
+    }
+
+    def "Read values (Kusama)"() {
+        BalanceReader reader = new BalanceReader(SS58Type.Network.CANARY)
+
+        expect:
+        new ScaleCodecReader(Hex.decodeHex(hex)).read(reader) == balance
+        where:
+        hex                                 | balance
+        "f70af5f6f3c843050000000000000000"  | DotAmount.fromPlancks(379367743775116023L, DotAmount.Kusamas)
+        "0000c52ebca2b1000000000000000000"  | DotAmount.from(50000, DotAmount.Kusamas)
+        "00000000000000000000000000000000"  | DotAmount.from(0, DotAmount.Kusamas)
+    }
+
+    def "Read values (Westend)"() {
+        BalanceReader reader = new BalanceReader(SS58Type.Network.SUBSTRATE)
+
+        expect:
+        new ScaleCodecReader(Hex.decodeHex(hex)).read(reader) == balance
+        where:
+        hex                                 | balance
+        "f70af5f6f3c843050000000000000000"  | DotAmount.fromPlancks(379367743775116023L, DotAmount.Westies)
+        "0000c52ebca2b1000000000000000000"  | DotAmount.from(50000, DotAmount.Westies)
+        "00000000000000000000000000000000"  | DotAmount.from(0, DotAmount.Westies)
     }
 }

--- a/polkaj-scale-types/src/test/groovy/io/emeraldpay/polkaj/scaletypes/ExtrinsicReaderSpec.groovy
+++ b/polkaj-scale-types/src/test/groovy/io/emeraldpay/polkaj/scaletypes/ExtrinsicReaderSpec.groovy
@@ -2,7 +2,6 @@ package io.emeraldpay.polkaj.scaletypes
 
 import io.emeraldpay.polkaj.scale.ScaleCodecReader
 import io.emeraldpay.polkaj.scale.UnionValue
-import io.emeraldpay.polkaj.scale.reader.UnionReader
 import io.emeraldpay.polkaj.ss58.SS58Type
 import io.emeraldpay.polkaj.types.Address
 import io.emeraldpay.polkaj.types.DotAmount
@@ -28,7 +27,7 @@ class ExtrinsicReaderSpec extends Specification {
             sender == new UnionValue(0, new MultiAddress.AccountID(Address.from("GksmaqmLPbfQhsNgT2S5GcwwTkGXCpkPU8FDzxP4siKPAVu")))
             era == 229
             nonce == 3
-            tip == DotAmount.ZERO
+            tip == DotAmount.from(0, DotAmount.Kusamas)
             signature.getType() == Extrinsic.SignatureType.SR25519
             signature.getValue() == Hash512.from("0xbc11655de6e7461b0951353db25f4aaf67a58db547fa3a2f20cbcd7772ba715f8ccbe9d8bddf253c7f6e6f6acb83848a7da1f27de248afca10d3291de92ede8c")
         }
@@ -36,7 +35,35 @@ class ExtrinsicReaderSpec extends Specification {
             moduleIndex == 4
             callIndex == 0
             destination == new UnionValue(0, new MultiAddress.AccountID(Address.from("ED3aw4s68wTDscCbWnCCw94qSrkA1D8HcUXC8ytaoM2X2xd")))
-            balance == DotAmount.fromDots(3.451)
+            balance == DotAmount.from(0.03451, DotAmount.Kusamas)
+        }
+    }
+
+    def "Parse transfer_keep_alive"() {
+        setup:
+        def existing = "51028400a6a11c9cf2b58fd914ffc8f667e31e8e6175514833a2892100c8c3bcc904906100634c879c40daf331254bafdbfb24ac3f5286f60d38ed4d056caffd6c5efbd8451fbb0e277f2be832e8e8aad428492c25e8f354f9976500a41e8943284a4e540b0004074ea0efcd01040300b587b6f4e35da071696161b345b378eb282c884a03d23cf7e44ba27cf3f63d4c070088526a74"
+        ExtrinsicReader<BalanceTransfer> reader = new ExtrinsicReader<>(
+                new BalanceTransferReader(SS58Type.Network.SUBSTRATE),
+                SS58Type.Network.SUBSTRATE
+        )
+        when:
+        def rdr = new ScaleCodecReader(Hex.decodeHex(existing))
+        def act = reader.read(rdr)
+
+        then:
+        with(act.tx) {
+            sender == new UnionValue(0, new MultiAddress.AccountID(Address.from("5FqBfbPzAD8v8M3XQQEixXJW7HmXZ8JLqLfibxj8zjuPkipz")))
+            era == 0
+            nonce == 1
+            tip == DotAmount.fromPlancks(7750000718, DotAmount.Westies)
+            signature.getType() == Extrinsic.SignatureType.ED25519
+            signature.getValue() == Hash512.from("0x634c879c40daf331254bafdbfb24ac3f5286f60d38ed4d056caffd6c5efbd8451fbb0e277f2be832e8e8aad428492c25e8f354f9976500a41e8943284a4e540b")
+        }
+        with(act.call) {
+            moduleIndex == 4
+            callIndex == 3
+            destination == new UnionValue(0, new MultiAddress.AccountID(Address.from("5GAiqfv7kwGxnLpCue9pFt7zwt4u1aoYM7p9tHJPGMjNHpEz")))
+            balance == DotAmount.from(0.5, DotAmount.Westies)
         }
     }
 }

--- a/polkaj-scale-types/src/test/groovy/io/emeraldpay/polkaj/scaletypes/ExtrinsicSpec.groovy
+++ b/polkaj-scale-types/src/test/groovy/io/emeraldpay/polkaj/scaletypes/ExtrinsicSpec.groovy
@@ -50,8 +50,15 @@ class ExtrinsicSpec extends Specification {
     def "SR25519 Signature Equals"() {
         when:
         def v = EqualsVerifier.forClass(Extrinsic.SR25519Signature)
-                .suppress(Warning.STRICT_INHERITANCE)
-                .suppress(Warning.NONFINAL_FIELDS)
+                .usingGetClass()
+        then:
+        v.verify()
+    }
+
+    def "ED25519 Signature Equals"() {
+        when:
+        def v = EqualsVerifier.forClass(Extrinsic.ED25519Signature)
+                .usingGetClass()
         then:
         v.verify()
     }

--- a/polkaj-scale-types/src/test/groovy/io/emeraldpay/polkaj/scaletypes/ExtrinsicWriterSpec.groovy
+++ b/polkaj-scale-types/src/test/groovy/io/emeraldpay/polkaj/scaletypes/ExtrinsicWriterSpec.groovy
@@ -36,4 +36,32 @@ class ExtrinsicWriterSpec extends Specification {
         then:
         act == "41028400b8fdf4f080eeaa6d3f32a445c91c7effa6ffef16d5fe81783837ab7a23602b3b01bc11655de6e7461b0951353db25f4aaf67a58db547fa3a2f20cbcd7772ba715f8ccbe9d8bddf253c7f6e6f6acb83848a7da1f27de248afca10d3291de92ede8ce5000c00040000483eae8765348ef3e347e6b55995f99353223a8b28cf63829554933bcd5e801d0780cff40808"
     }
+
+    def "Encode known transfer_keep_alive"() {
+        setup:
+        def codec = new ExtrinsicWriter(new BalanceTransferWriter())
+        def tx = new Extrinsic().tap {
+            tx = new Extrinsic.TransactionInfo().tap {
+                sender = Address.from("5FqBfbPzAD8v8M3XQQEixXJW7HmXZ8JLqLfibxj8zjuPkipz")
+                era = 0
+                nonce = 0
+                tip = DotAmount.fromPlancks(7750000718L, DotAmount.Westies)
+                signature = new Extrinsic.ED25519Signature(
+                        Hash512.from("0x6b47873769d702332fc2dd76d2891178c3b813aa2175c06b31074e6b163ecb95196c6a520894d4f1a36806490d7213a213834d6c12186bf89ce311d481ae1d09")
+                )
+            }
+            call = new BalanceTransfer(4, 3).tap {
+                destination = Address.from("5GAiqfv7kwGxnLpCue9pFt7zwt4u1aoYM7p9tHJPGMjNHpEz")
+                balance = DotAmount.from(0.1, DotAmount.Westies)
+            }
+        }
+        when:
+        def buf = new ByteArrayOutputStream()
+        def writer = new ScaleCodecWriter(buf)
+        writer.write(codec, tx)
+        writer.close()
+        def act = Hex.encodeHexString(buf.toByteArray())
+        then:
+        act == "51028400a6a11c9cf2b58fd914ffc8f667e31e8e6175514833a2892100c8c3bcc9049061006b47873769d702332fc2dd76d2891178c3b813aa2175c06b31074e6b163ecb95196c6a520894d4f1a36806490d7213a213834d6c12186bf89ce311d481ae1d090000074ea0efcd01040300b587b6f4e35da071696161b345b378eb282c884a03d23cf7e44ba27cf3f63d4c0700e8764817"
+    }
 }

--- a/polkaj-scale/src/main/java/io/emeraldpay/polkaj/scale/UnionValue.java
+++ b/polkaj-scale/src/main/java/io/emeraldpay/polkaj/scale/UnionValue.java
@@ -44,4 +44,12 @@ public class UnionValue<T> {
     public int hashCode() {
         return Objects.hash(index, value);
     }
+
+    @Override
+    public String toString() {
+        return "UnionValue{" +
+                "index=" + index +
+                ", value=" + value +
+                '}';
+    }
 }

--- a/polkaj-tx/src/main/java/io/emeraldpay/polkaj/tx/AccountRequests.java
+++ b/polkaj-tx/src/main/java/io/emeraldpay/polkaj/tx/AccountRequests.java
@@ -3,6 +3,7 @@ package io.emeraldpay.polkaj.tx;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 import io.emeraldpay.polkaj.scale.ScaleCodecReader;
 import io.emeraldpay.polkaj.scale.ScaleCodecWriter;
@@ -14,6 +15,8 @@ import io.emeraldpay.polkaj.scaletypes.BalanceTransferWriter;
 import io.emeraldpay.polkaj.scaletypes.Extrinsic;
 import io.emeraldpay.polkaj.scaletypes.ExtrinsicWriter;
 import io.emeraldpay.polkaj.scaletypes.Metadata;
+import io.emeraldpay.polkaj.schnorrkel.Schnorrkel;
+import io.emeraldpay.polkaj.ss58.SS58Type;
 import io.emeraldpay.polkaj.types.Address;
 import io.emeraldpay.polkaj.types.ByteData;
 import io.emeraldpay.polkaj.types.DotAmount;
@@ -193,8 +196,8 @@ public class AccountRequests {
         }
 
         /**
-         * (optional) Set once, if setting a presefined signature.
-         * Otherwise nonce is set during {@link #sign} operation
+         * (optional) Set once, if setting a predefined signature.
+         * Otherwise, nonce is set during {@link #sign} operation
          *
          * @param nonce once to use
          * @return builder
@@ -229,6 +232,7 @@ public class AccountRequests {
         /**
          * Sign the transfer
          *
+         * @param key sender key pair
          * @param context signing context
          * @return builder
          * @throws SignException if signing is failed
@@ -247,7 +251,7 @@ public class AccountRequests {
             }
             ExtrinsicSigner<BalanceTransfer> signer = new ExtrinsicSigner<>(new BalanceTransferWriter());
             return this.nonce(context)
-                    .signed(new Extrinsic.SR25519Signature(signer.sign(context, this.call)));
+                    .signed(new Extrinsic.SR25519Signature(signer.sign(context, this.call, key)));
         }
 
         /**

--- a/polkaj-tx/src/main/java/io/emeraldpay/polkaj/tx/AccountRequests.java
+++ b/polkaj-tx/src/main/java/io/emeraldpay/polkaj/tx/AccountRequests.java
@@ -67,7 +67,7 @@ public class AccountRequests {
 
         @Override
         public DotAmount apply(ByteData result) {
-            return new ScaleCodecReader(result.getBytes()).read(BalanceReader.INSTANCE);
+            return new ScaleCodecReader(result.getBytes()).read(new BalanceReader());
         }
     }
 
@@ -97,7 +97,7 @@ public class AccountRequests {
             if (result == null) {
                 return null;
             }
-            return new ScaleCodecReader(result.getBytes()).read(new AccountInfoReader());
+            return new ScaleCodecReader(result.getBytes()).read(new AccountInfoReader(address.getNetwork()));
         }
     }
 

--- a/polkaj-tx/src/main/java/io/emeraldpay/polkaj/tx/ExtrinsicContext.java
+++ b/polkaj-tx/src/main/java/io/emeraldpay/polkaj/tx/ExtrinsicContext.java
@@ -1,5 +1,8 @@
 package io.emeraldpay.polkaj.tx;
 
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
 import io.emeraldpay.polkaj.api.PolkadotApi;
 import io.emeraldpay.polkaj.api.StandardCommands;
 import io.emeraldpay.polkaj.json.RuntimeVersionJson;
@@ -7,9 +10,6 @@ import io.emeraldpay.polkaj.scaletypes.AccountInfo;
 import io.emeraldpay.polkaj.types.Address;
 import io.emeraldpay.polkaj.types.DotAmount;
 import io.emeraldpay.polkaj.types.Hash256;
-
-import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Context to execute an Extrinsic
@@ -249,5 +249,19 @@ public class ExtrinsicContext {
                             .genesis(genesis.join())
                     );
         }
+    }
+
+    @Override
+    public String toString() {
+        return "ExtrinsicContext{" +
+                "txVersion=" + txVersion +
+                ", runtimeVersion=" + runtimeVersion +
+                ", genesis=" + genesis +
+                ", eraBlockHash=" + eraBlockHash +
+                ", nonce=" + nonce +
+                ", era=" + era +
+                ", tip=" + tip +
+                ", eraHeight=" + eraHeight +
+                '}';
     }
 }

--- a/polkaj-tx/src/test/groovy/io/emeraldpay/polkaj/tx/AccountRequestsSpec.groovy
+++ b/polkaj-tx/src/test/groovy/io/emeraldpay/polkaj/tx/AccountRequestsSpec.groovy
@@ -1,6 +1,6 @@
 package io.emeraldpay.polkaj.tx
 
-
+import io.emeraldpay.polkaj.scaletypes.Extrinsic
 import io.emeraldpay.polkaj.types.Address
 import io.emeraldpay.polkaj.types.ByteData
 import io.emeraldpay.polkaj.types.DotAmount
@@ -62,11 +62,28 @@ class AccountRequestsSpec extends Specification {
             .to(Address.from("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"))
             .nonce(1234567890)
             .amount(DotAmount.fromDots(123))
-            .signed(Hash512.from("0x6a141ade40871c076f3eb32362f0204db49e4ae37e5dc7a68329f1a6768034556201432b1635637fc1d42ae6fce996fb25ef175ee1ae4015d2b8769436d89987"))
+            .signed(new Extrinsic.SR25519Signature(Hash512.from("0x6a141ade40871c076f3eb32362f0204db49e4ae37e5dc7a68329f1a6768034556201432b1635637fc1d42ae6fce996fb25ef175ee1ae4015d2b8769436d89987")))
             .build()
         def act = transfer.encodeRequest()
         then:
         act.toString() == "0x51028400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d016a141ade40871c076f3eb32362f0204db49e4ae37e5dc7a68329f1a6768034556201432b1635637fc1d42ae6fce996fb25ef175ee1ae4015d2b8769436d899870003d2029649000500008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a480b008cb6611e01"
+    }
+
+     def "Encode transfer_keep_alive"() {
+        when:
+        def transfer = AccountRequests.transferKeepAlive()
+            .module(4, 3)
+            .from(Address.from("5FqBfbPzAD8v8M3XQQEixXJW7HmXZ8JLqLfibxj8zjuPkipz"))
+            .to(Address.from("5GAiqfv7kwGxnLpCue9pFt7zwt4u1aoYM7p9tHJPGMjNHpEz"))
+            .nonce(1)
+            .amount(DotAmount.from(0.5, DotAmount.Westies))
+            .tip(DotAmount.fromPlancks(7750000718L, DotAmount.Westies))
+            .signed(new Extrinsic.ED25519Signature(
+                    Hash512.from("0x634c879c40daf331254bafdbfb24ac3f5286f60d38ed4d056caffd6c5efbd8451fbb0e277f2be832e8e8aad428492c25e8f354f9976500a41e8943284a4e540b")))
+            .build()
+        def act = transfer.encodeRequest()
+        then:
+        act.toString() == "0x51028400a6a11c9cf2b58fd914ffc8f667e31e8e6175514833a2892100c8c3bcc904906100634c879c40daf331254bafdbfb24ac3f5286f60d38ed4d056caffd6c5efbd8451fbb0e277f2be832e8e8aad428492c25e8f354f9976500a41e8943284a4e540b0004074ea0efcd01040300b587b6f4e35da071696161b345b378eb282c884a03d23cf7e44ba27cf3f63d4c070088526a74"
     }
 
     def "Sign and encode transfer"() {

--- a/polkaj-tx/src/test/groovy/io/emeraldpay/polkaj/tx/ExtrinsicSignerSpec.groovy
+++ b/polkaj-tx/src/test/groovy/io/emeraldpay/polkaj/tx/ExtrinsicSignerSpec.groovy
@@ -2,6 +2,8 @@ package io.emeraldpay.polkaj.tx
 
 import io.emeraldpay.polkaj.scaletypes.BalanceTransfer
 import io.emeraldpay.polkaj.scaletypes.BalanceTransferWriter
+import io.emeraldpay.polkaj.scaletypes.Extrinsic
+import io.emeraldpay.polkaj.types.Address
 import io.emeraldpay.polkaj.types.DotAmount
 import io.emeraldpay.polkaj.types.Hash256
 import io.emeraldpay.polkaj.types.Hash512
@@ -43,7 +45,7 @@ class ExtrinsicSignerSpec extends Specification {
 
         when:
         def valid = signer.isValid(extrinsic, call,
-                Hash512.from("0x46176d89b00e11521fba7962ea18e6c4279bc32deda3140b3718f75c2cecba15915c2124cc13767bb6a8fea536788ba23fc40d54d90f8e82ffcb2c59f838808c"),
+                new Extrinsic.SR25519Signature(Hash512.from("0x46176d89b00e11521fba7962ea18e6c4279bc32deda3140b3718f75c2cecba15915c2124cc13767bb6a8fea536788ba23fc40d54d90f8e82ffcb2c59f838808c")),
                 TestKeys.alice
         )
         then:
@@ -69,7 +71,7 @@ class ExtrinsicSignerSpec extends Specification {
 
         when:
         def valid = signer.isValid(extrinsic, call,
-                Hash512.from("0xc6d3033548c4b2752b50da78e936d894d946de79b14be126a9dd61100c736d7a6a66c2973ebc8f65ed969a1de0f9cecdeaf8c22130486a27a875f8b35ce5828c"),
+                new Extrinsic.SR25519Signature(Hash512.from("0xc6d3033548c4b2752b50da78e936d894d946de79b14be126a9dd61100c736d7a6a66c2973ebc8f65ed969a1de0f9cecdeaf8c22130486a27a875f8b35ce5828c")),
                 TestKeys.alice
         )
         then:
@@ -95,7 +97,7 @@ class ExtrinsicSignerSpec extends Specification {
 
         when:
         def valid = signer.isValid(extrinsic, call,
-                Hash512.from("0x98cee3be271b0e127c5142d6823be37bccba77c297c0a1d131c76f9d820d1830be80711b1c86fde8b40f75cd4534666a5b8f41939b4614bfb6dfae1a96d1a88a"),
+                new Extrinsic.SR25519Signature(Hash512.from("0x98cee3be271b0e127c5142d6823be37bccba77c297c0a1d131c76f9d820d1830be80711b1c86fde8b40f75cd4534666a5b8f41939b4614bfb6dfae1a96d1a88a")),
                 TestKeys.alice
         )
         then:
@@ -122,7 +124,7 @@ class ExtrinsicSignerSpec extends Specification {
         Hex.encodeHexString(payload) == "a80500008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a480b0030ef7dba024e9c1c0012000000030000004c0bdd177c17ca145ad9a3e76d092d4d4baa8add4fa8c78cc2fbbf8e3cbd51224baa8add4fa8c78cc2fbbf8e3cbd51224c0bdd177c17ca145ad9a3e76d092d4d"
         when:
         def valid = signer.isValid(extrinsic, call,
-                Hash512.from("0xe22aab207ae5cc08c5d4106ff4b8f0c6b6bb2dddbf3b143462d9b1aa8ad8d162a3e78a3d6d656b115fd0756cc61e89943d3eb9a971740ade59938a933f85d58c"),
+                new Extrinsic.SR25519Signature(Hash512.from("0xe22aab207ae5cc08c5d4106ff4b8f0c6b6bb2dddbf3b143462d9b1aa8ad8d162a3e78a3d6d656b115fd0756cc61e89943d3eb9a971740ade59938a933f85d58c")),
                 TestKeys.alice
         )
         then:
@@ -142,12 +144,35 @@ class ExtrinsicSignerSpec extends Specification {
             destination = TestKeys.bob
             balance = DotAmount.fromDots(amount)
         }
-        def signature = signer.sign(context, call, TestKeys.aliceKey)
+        def signature = new Extrinsic.SR25519Signature(signer.sign(context, call, TestKeys.aliceKey))
         signer.isValid(context, call, signature, TestKeys.alice)
         where:
         amount      | nonce
         1.0         | 0
         100.0       | 100
         1.1234      | 256
+    }
+
+    def "Validate own ED25519 signature"() {
+        setup:
+        ExtrinsicSigner signer = new ExtrinsicSigner<>(new BalanceTransferWriter())
+        expect:
+        ExtrinsicContext context = ExtrinsicContext.newBuilder()
+                .runtime(5, 9090)
+                .genesis(Hash256.from("0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e"))
+                .nonce(1)
+                .tip(DotAmount.fromPlancks(7750000718, DotAmount.Westies))
+                .build()
+        BalanceTransfer call = new BalanceTransfer(4, 3).tap {
+            destination = Address.from("5GAiqfv7kwGxnLpCue9pFt7zwt4u1aoYM7p9tHJPGMjNHpEz")
+            balance = DotAmount.from(0.5, DotAmount.Westies)
+        }
+        def signature = new Extrinsic.ED25519Signature(
+                Hash512.from("0x634c879c40daf331254bafdbfb24ac3f5286f60d38ed4d056caffd6c5efbd8451fbb0e277f2be832e8e8aad428492c25e8f354f9976500a41e8943284a4e540b"))
+        def source = Address.from("5FqBfbPzAD8v8M3XQQEixXJW7HmXZ8JLqLfibxj8zjuPkipz")
+        when:
+        def valid = signer.isValid(context, call, signature, source)
+        then:
+        valid
     }
 }


### PR DESCRIPTION
Introduce a separate Signature class to support both SR25519 and ED25519 signatures.
Read and write signature from/to byte array with correct type.
Allow setting the tip via TransferBuilder so the encoded unsigned ByteData contains the tip as well.
Add toString() methods to the scale types for easier debugging.