### PR TITLE
hash length mistake of ExtrinsicSigner.java

### DIFF
--- a/polkaj-tx/src/main/java/io/emeraldpay/polkaj/tx/ExtrinsicSigner.java
+++ b/polkaj-tx/src/main/java/io/emeraldpay/polkaj/tx/ExtrinsicSigner.java
@@ -67,7 +67,7 @@ public class ExtrinsicSigner<CALL extends ExtrinsicCall> {
             throw new SignException("Failed to encode signature payload", e);
         }
         byte[] bytes = result.toByteArray();
-        if (bytes.length > 256) {
+        if (bytes.length > 32) {
             return Hashing.blake2(bytes);
         } else {
             return bytes;


### PR DESCRIPTION
hash is 32 byte length